### PR TITLE
Introducing `ObservableMutableSafePointer`!

### DIFF
--- a/Sources/SafePointer/MutablePointer.swift
+++ b/Sources/SafePointer/MutablePointer.swift
@@ -1,0 +1,31 @@
+//
+//  MutablePointer.swift
+//  SafePointer
+//
+//  Created by Ben Leggiero on 2019-08-11.
+//  Copyright © 2019 Blue Husky Studios BH-0-PD
+//  https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-0-PD.txt
+//
+
+/// A `Pointer` which can be changed to point at some other instance
+public protocol MutablePointer: Pointer {
+    
+    /// The instance this pointer points to
+    var pointee: Pointee { get set }
+    
+    /// Creates a new pointer, points it at the given instance, and sets up a change listener
+    ///
+    /// - Parameters:
+    ///   - pointee:            The instance to which this pointer will point
+    ///   - onPointeeDidChange: _optional_ - Called immediately after `pointee` changes
+    init(to pointee: Pointee, onPointeeDidChange: @escaping OnPointeeDidChange)
+    
+    
+    
+    /// The kind of function which can respond to a pointee changing
+    ///
+    /// - Parameters:
+    ///   - oldValue: A snapshot of what `pointee` was before it changed
+    ///   - newValue: A snapshot of what `pointee` was after it changed
+    typealias OnPointeeDidChange = (_ oldValue: Pointee, _ newValue: Pointee) -> Void
+}

--- a/Sources/SafePointer/MutableSafePointer.swift
+++ b/Sources/SafePointer/MutableSafePointer.swift
@@ -1,0 +1,53 @@
+//
+//  MutableSafePointer.swift
+//  SafePointer
+//
+//  Created by Ben Leggiero on 2019-08-11.
+//  Copyright © 2019 Blue Husky Studios BH-0-PD
+//  https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-0-PD.txt
+//
+
+/// A mutable pointer which carries no danger in its use. If there's a crash, it won't be `MutableSafePointer`'s fault!
+@propertyWrapper
+public final class MutableSafePointer<Value>: SafePointer<Value>, MutablePointer {
+    
+    override public var pointee: Value {
+        get { _pointee }
+        set {
+            let oldValue = _pointee
+            _pointee = newValue
+            onPointeeDidChange?(oldValue, newValue)
+        }
+    }
+    
+    
+    /// The function which will be called after `pointee` changes
+    private var onPointeeDidChange: OnPointeeDidChange?
+    
+    
+    public init(to pointee: Value, onPointeeDidChange: @escaping OnPointeeDidChange) {
+        super.init(to: pointee)
+        self.onPointeeDidChange = onPointeeDidChange
+    }
+    
+    
+    public required init(to pointee: Value) {
+        super.init(to: pointee)
+    }
+    
+    
+    // MARK: Property wrapper
+    
+    override public var wrappedValue: Value {
+        get { self.pointee }
+        set { self.pointee = newValue }
+    }
+    
+    public convenience init(wrappedValue: Value) {
+        self.init(to: wrappedValue)
+    }
+}
+
+
+
+typealias SafeMutablePointer<Value> = MutableSafePointer<Value>

--- a/Sources/SafePointer/ObservableMutableSafePointer.swift
+++ b/Sources/SafePointer/ObservableMutableSafePointer.swift
@@ -1,9 +1,9 @@
 //
-//  MutablePointer.swift
+//  ObservableMutableSafePointer.swift
 //  SafePointer
 //
 //  Created by Ben Leggiero on 2020-03-22.
-//  Copyright © 2019 Blue Husky Studios BH-0-PD
+//  Copyright © 2020 Blue Husky Studios BH-0-PD
 //  https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-0-PD.txt
 //
 

--- a/Sources/SafePointer/ObservableMutableSafePointer.swift
+++ b/Sources/SafePointer/ObservableMutableSafePointer.swift
@@ -1,0 +1,156 @@
+//
+//  MutablePointer.swift
+//  SafePointer
+//
+//  Created by Ben Leggiero on 2020-03-22.
+//  Copyright © 2019 Blue Husky Studios BH-0-PD
+//  https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-0-PD.txt
+//
+
+/// A mutable pointer which carries no danger in its use, and whose changes can be safely observed by many things.
+/// If there's a crash, it won't be `ObservableMutableSafePointer`'s fault!
+@propertyWrapper
+public final class ObservableMutableSafePointer<Value>: SafePointer<Value>, MutablePointer {
+    
+    override public var pointee: Value {
+        get { _pointee }
+        set {
+            let oldValue = _pointee
+            _pointee = newValue
+            onPointeeDidChangeQueue.forEach { $0.observer(oldValue, newValue) }
+        }
+    }
+    
+    
+    /// The queue of functions which will be called after `pointee` changes.
+    ///
+    /// Guaranteed to be called in the order in which the observers were added
+    private var onPointeeDidChangeQueue: AddedObservers = []
+//    private var indexCache: [ObserverIdentifier : AddedObservers.Index] = [:] // TODO: Use something like this to efficiently remove an observer
+    
+    
+    /// Creates a new observable, mutable, safe pointer to the given value
+    ///
+    /// - Parameters:
+    ///   - pointee:               The value to point to
+    ///   - newObserverIdentifier: _optional_ - The identifier for the observer. You can use this later to remove the
+    ///                            observer. Pass any value (I recommend `ObserverIdentifier()`), and after this
+    ///                            initializer completes, it will have been set to the observer identifier. The initial
+    ///                            value you pass in will be ignored.
+    ///   - onPointeeDidChange:    A function which will be called when the pointee changes
+    public init(to pointee: Value, newObserverIdentifier: inout ObserverIdentifier, onPointeeDidChange: @escaping OnPointeeDidChange) {
+        super.init(to: pointee)
+        newObserverIdentifier = addObserver(onPointeeDidChange)
+    }
+    
+    
+    /// Creates a new observable, mutable, safe pointer to the given value
+    ///
+    /// - Parameters:
+    ///   - pointee:               The value to point to
+    ///   - newObserverIdentifier: _optional_ - The identifier for the observer. You can use this later to remove the
+    ///                            observer. Pass any value (I recommend `ObserverIdentifier()`), and after this
+    ///                            initializer completes, it will have been set to the observer identifier.
+    ///   - onPointeeDidChange:    A function which will be called when the pointee changes
+    public init(to pointee: Value, onPointeeDidChange: @escaping OnPointeeDidChange) {
+        super.init(to: pointee)
+        addObserver(onPointeeDidChange)
+    }
+    
+    
+    /// Creates a new observable, mutable, safe pointer to the given value
+    ///
+    /// - Parameter pointee: The value to point to
+    public required init(to pointee: Value) {
+        super.init(to: pointee)
+    }
+    
+    
+    // MARK: Property wrapper
+    
+    override public var wrappedValue: Value { self.pointee }
+    
+    public convenience init(wrappedValue: Value) {
+        self.init(to: wrappedValue)
+    }
+}
+
+
+
+// MARK: - Observation
+
+public extension ObservableMutableSafePointer {
+    
+    /// Adds the given function to be called whenever this pointer changes.
+    ///
+    /// When this pointer goes out of scope, all of its observers are automatically and immediately removed. If you
+    /// don't intend to remove the observer before this pointer goes out of scope, then you can ignore the return value
+    ///
+    /// - Parameter onPointeeDidChange: The function to be called when the pointee changes
+    /// - Returns: _optional_ - The identifier for the observer. You can use this later to remove the observer.
+    @discardableResult
+    func addObserver(_ onPointeeDidChange: @escaping OnPointeeDidChange) -> ObserverIdentifier {
+        let identifier = ObserverIdentifier.random(in: .min ... .max)
+        self.onPointeeDidChangeQueue.append((identifier: identifier, observer: onPointeeDidChange))
+//        indexCache[identifier] = self.onPointeeDidChangeQueue.endIndex.advanced(by: -1)
+        return identifier
+    }
+    
+    
+    /// Removes the observer which has the given identifier
+    ///
+    /// If the given identifier refers to an observer which was already removed (or which was never added at all),
+    /// nothing special happens; this just returns `.observerNotFound`.
+    ///
+    /// If an observer is removed before it finishes running, this class doesn't try to stop it nor hold onto it.
+    ///
+    /// - Complexity: O(n)
+    ///
+    /// See https://github.com/RougeWare/Swift-Safe-Pointer/issues/8
+    ///
+    /// - Parameter identifier: The identifier which corresponds to a function you want to remove
+    /// - Returns: _optional_ - `.removedSuccessfully` iff an observer with the given identifier was found and removed.
+    ///                         Otherwise, `.observerNotFound`.
+    @discardableResult
+    func removeObserver(withId identifier: ObserverIdentifier) -> RemoveObserverResult {
+        guard let index = onPointeeDidChangeQueue.firstIndex(where: { $0.identifier == identifier }) else {
+            return .observerNotFound
+        }
+        
+        onPointeeDidChangeQueue.remove(at: index)
+//        indexCache.removeValue(forKey: identifier)
+        return .removedSuccessfully
+    }
+    
+    
+    
+    /// The type of identifier used to identify a function that's been added to the observer queue
+    typealias ObserverIdentifier = Int
+    
+    /// An observer that's been added to the observer queue, and its corresponding identifier
+    fileprivate typealias AddedObserver = (identifier: ObserverIdentifier, observer: OnPointeeDidChange)
+    
+    /// The type of collection this uses to track added observers
+    fileprivate typealias AddedObservers = [AddedObserver]
+    
+    
+    
+    /// The result of attempting to remove an observer
+    enum RemoveObserverResult {
+        
+        /// The observer was found and removed from the observer queue
+        case removedSuccessfully
+        
+        /// The observer was not found, so no action was taken
+        case observerNotFound
+    }
+}
+
+
+                                                                                    // OMS   P
+typealias MutableSafeObservablePointer<Value> = ObservableMutableSafePointer<Value> //  MSO  P
+typealias SafeObservableMutablePointer<Value> = ObservableMutableSafePointer<Value> //   SOM P
+typealias MutableObservableSafePointer<Value> = ObservableMutableSafePointer<Value> // MOS   P
+typealias ObservableSafeMutablePointer<Value> = ObservableMutableSafePointer<Value> //  OSM  P
+typealias SafeMutableObservablePointer<Value> = ObservableMutableSafePointer<Value> //   SMO P
+

--- a/Sources/SafePointer/Pointer.swift
+++ b/Sources/SafePointer/Pointer.swift
@@ -1,0 +1,29 @@
+//
+//  Pointer.swift
+//  SafePointer
+//
+//  Created by Ben Leggiero on 2019-08-11.
+//  Copyright © 2019 Blue Husky Studios BH-0-PD
+//  https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-0-PD.txt
+//
+
+/// Lets you pass anything using reference semantics without the danger of unsafe pointers.
+///
+/// Do note that this is more of a conceptual pointer; one which points to some intance. This acknowledges no concept
+/// of memory addresses nor traversing memory. For that, you can use Swift's built-in `UnsafePointer` and its sisters.
+public protocol Pointer: class {
+    
+    /// The type of the instance that this pointer points to
+    associatedtype Pointee
+    
+    
+    
+    /// The instance this pointer points to
+    var pointee: Pointee { get }
+    
+    
+    /// Creates a new pointer and points it at the given instance
+    ///
+    /// - Parameter pointee: The instance to which this pointer will point
+    init(to pointee: Pointee)
+}

--- a/Sources/SafePointer/SafePointer.swift
+++ b/Sources/SafePointer/SafePointer.swift
@@ -7,68 +7,12 @@
 //  https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-0-PD.txt
 //
 
-
-
-// MARK: - Pointer protocol
-
-/// Lets you pass anything using reference semantics without the danger of unsafe pointers.
-///
-/// Do note that this is more of a conceptual pointer; one which points to some intance. This acknowledges no concept
-/// of memory addresses nor traversing memory. For that, you can use Swift's built-in `UnsafePointer` and its sisters.
-public protocol Pointer: class {
-    
-    /// The type of the instance that this pointer points to
-    associatedtype Pointee
-    
-    
-    
-    /// The instance this pointer points to
-    var pointee: Pointee { get }
-    
-    
-    /// Creates a new pointer and points it at the given instance
-    ///
-    /// - Parameter pointee: The instance to which this pointer will point
-    init(to pointee: Pointee)
-}
-
-
-
-// MARK: - MutablePointer protocol
-
-/// A `Pointer` which can be changed to point at some other instance
-public protocol MutablePointer: Pointer {
-    
-    /// The instance this pointer points to
-    var pointee: Pointee { get set }
-    
-    /// Creates a new pointer, points it at the given instance, and sets up a change listener
-    ///
-    /// - Parameters:
-    ///   - pointee:            The instance to which this pointer will point
-    ///   - onPointeeDidChange: _optional_ - Called immediately after `pointee` changes
-    init(to pointee: Pointee, onPointeeDidChange: @escaping OnPointeeDidChange)
-    
-    
-    
-    /// The kind of function which can respond to a pointee changing
-    ///
-    /// - Parameters:
-    ///   - oldValue: A snapshot of what `pointee` was before it changed
-    ///   - newValue: A snapshot of what `pointee` was after it changed
-    typealias OnPointeeDidChange = (_ oldValue: Pointee, _ newValue: Pointee) -> Void
-}
-
-
-
-// MARK: - SafePointer
-
 /// A pointer which carries no danger in its use. If there's a crash, it won't be `SafePointer`'s fault!
 @propertyWrapper
 public class SafePointer<Value>: Pointer {
     
     /// This is so the pass-by-reference semantics make sense to the Swift compiler
-    fileprivate var _pointee: Value
+    internal var _pointee: Value
     
     public var pointee: Value { _pointee }
     
@@ -80,57 +24,13 @@ public class SafePointer<Value>: Pointer {
     
     // MARK: Property wrapper
     
-    /// The same `pointee`
+    /// The same as `pointee`
     public var wrappedValue: Value { pointee }
     
     
     /// The same as `.init(to:)`
     ///
     /// - Parameter wrappedValue: The pointee
-    public convenience init(wrappedValue: Value) {
-        self.init(to: wrappedValue)
-    }
-}
-
-
-// MARK: - MutableSafePointer
-
-/// A mutable pointer which carries no danger in its use. If there's a crash, it won't be `MutableSafePointer`'s fault!
-@propertyWrapper
-public final class MutableSafePointer<Value>: SafePointer<Value>, MutablePointer {
-    
-    override public var pointee: Value {
-        get { _pointee }
-        set {
-            let oldValue = _pointee
-            _pointee = newValue
-            onPointeeDidChange?(oldValue, newValue)
-        }
-    }
-    
-    
-    /// The function which will be called after `pointee` changes
-    private var onPointeeDidChange: OnPointeeDidChange?
-    
-    
-    public init(to pointee: Value, onPointeeDidChange: @escaping OnPointeeDidChange) {
-        super.init(to: pointee)
-        self.onPointeeDidChange = onPointeeDidChange
-    }
-    
-    
-    public required init(to pointee: Value) {
-        super.init(to: pointee)
-    }
-    
-    
-    // MARK: Property wrapper
-    
-    override public var wrappedValue: Value {
-        get { self.pointee }
-        set { self.pointee = newValue }
-    }
-    
     public convenience init(wrappedValue: Value) {
         self.init(to: wrappedValue)
     }


### PR DESCRIPTION
Also:
- Broke out the different pointers into different files
- Added the `typealias` `SafeMutablePointer` so you don't have to remember the exact order of those words
